### PR TITLE
C++11 port

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ set(CMAKE_PREFIX_PATH "${TIXI_PATH};${CMAKE_PREFIX_PATH}")
 find_package(tixi3 3.0.3 REQUIRED)
 
 # lib
-file(GLOB LIB_INPUTS src/lib/*.cpp *src/lib/*.h)
+file(GLOB LIB_INPUTS src/lib/*.cpp *src/lib/*.h *src/lib/runtime/*.h)
 add_library(lib${PROJECT_NAME} ${LIB_INPUTS})
 target_link_libraries(lib${PROJECT_NAME} PUBLIC tixi3)
 source_group(" " FILES ${LIB_INPUTS})

--- a/src/lib/CodeGen.cpp
+++ b/src/lib/CodeGen.cpp
@@ -25,7 +25,7 @@ namespace tigl {
 
         const auto tixiHelperNamespace = "tixi";
         const auto c_uidMgrName = std::string("CTiglUIDManager");
-        const auto c_unboundedConstantName = "xsdUnbounded";
+        const auto c_unboundedConstantName = "tixi::xsdUnbounded";
     }
 
     namespace {

--- a/src/lib/CodeGen.cpp
+++ b/src/lib/CodeGen.cpp
@@ -25,6 +25,7 @@ namespace tigl {
 
         const auto tixiHelperNamespace = "tixi";
         const auto c_uidMgrName = std::string("CTiglUIDManager");
+        const auto c_unboundedConstantName = "xsdUnbounded";
     }
 
     namespace {
@@ -76,6 +77,12 @@ namespace tigl {
 
         auto requiresUidManager(const Class& c) {
             return selfOrAnyChildHasUidField(c);
+        }
+
+        auto formatMaxOccurs(unsigned int maxOccurs) -> std::string {
+            if (maxOccurs == tigl::xsd::unbounded)
+                return c_unboundedConstantName;
+            return std::to_string(maxOccurs);
         }
     }
 
@@ -449,7 +456,7 @@ namespace tigl {
                         if (f.xmlType == XMLConstruct::Attribute || f.xmlType == XMLConstruct::SimpleContent || f.xmlType == XMLConstruct::FundamentalTypeBase)
                             throw std::runtime_error("Attributes, simpleContents and bases cannot be vectors");
                         assert(!isAtt);
-                        cpp << tixiHelperNamespace << "::TixiReadElements(tixiHandle, xpath + \"/" << f.cpacsName << "\", " << f.fieldName() << ", " << f.minOccurs << ", " << f.maxOccurs << ");";
+                        cpp << tixiHelperNamespace << "::TixiReadElements(tixiHandle, xpath + \"/" << f.cpacsName << "\", " << f.fieldName() << ", " << f.minOccurs << ", " << formatMaxOccurs(f.maxOccurs) << ");";
                         break;
                 }
 
@@ -504,7 +511,7 @@ namespace tigl {
                         break;
                     case Cardinality::Vector:
                         const auto moreArgs = ctorArgumentList(itC->second, c);
-                        cpp << tixiHelperNamespace << "::TixiReadElements(tixiHandle, xpath + \"/" << f.cpacsName << "\", " << f.fieldName() << ", " << f.minOccurs << ", " << f.maxOccurs << (moreArgs.empty() ? "" : ", " + moreArgs) << ");";
+                        cpp << tixiHelperNamespace << "::TixiReadElements(tixiHandle, xpath + \"/" << f.cpacsName << "\", " << f.fieldName() << ", " << f.minOccurs << ", " << formatMaxOccurs(f.maxOccurs) << (moreArgs.empty() ? "" : ", " + moreArgs) << ");";
                         break;
                 }
                 return;

--- a/src/lib/SchemaParser.cpp
+++ b/src/lib/SchemaParser.cpp
@@ -470,7 +470,10 @@ namespace tigl {
                     element.minOccurs = 1;
                 else {
                     const auto minOccurs = document.textAttribute(xpath, "minOccurs");
-                    element.minOccurs = std::stoi(minOccurs);
+                    const auto minOccursInt = std::stoi(minOccurs);
+                    if (minOccursInt < 0)
+                        throw std::runtime_error("minOccurs is negative: " + xpath);
+                    element.minOccurs = minOccursInt;
                 }
 
                 // maxOccurs
@@ -479,9 +482,13 @@ namespace tigl {
                 else {
                     const auto maxOccurs = document.textAttribute(xpath, "maxOccurs");
                     if (maxOccurs == "unbounded")
-                        element.maxOccurs = std::numeric_limits<decltype(element.maxOccurs)>::max();
-                    else
-                        element.maxOccurs = std::stoi(maxOccurs);
+                        element.maxOccurs = unbounded;
+                    else {
+                        const auto maxOccursInt = std::stoi(maxOccurs);
+                        if (maxOccursInt < 0)
+                            throw std::runtime_error("maxOccurs is negative: " + xpath);
+                        element.maxOccurs = maxOccursInt;
+                    }
                 }
 
                 // type

--- a/src/lib/SchemaParser.h
+++ b/src/lib/SchemaParser.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include <limits>
 #include <unordered_map>
 
 #include "TixiDocument.h"
@@ -10,6 +11,8 @@
 
 namespace tigl {
     namespace xsd {
+        constexpr int unbounded = std::numeric_limits<unsigned int>::max();
+
         struct XSDElement {
             std::string xpath;
         };
@@ -26,8 +29,8 @@ namespace tigl {
         struct Element : XSDElement {
             std::string name;
             std::string type;
-            int minOccurs;
-            int maxOccurs;
+            unsigned int minOccurs;
+            unsigned int maxOccurs;
             std::string defaultValue;
             std::string documentation;
         };

--- a/src/lib/TypeSystem.cpp
+++ b/src/lib/TypeSystem.cpp
@@ -404,46 +404,6 @@ namespace tigl {
             }
         }
 
-        void prefixClashedEnumValues() {
-            std::unordered_map<std::string, std::vector<Enum*>> valueToEnum;
-
-            for (auto& p : m_enums) {
-                auto& e = p.second;
-                if (e.pruned)
-                    continue;
-                for (auto& v : e.values) {
-                    auto& otherEnums = valueToEnum[v.name()];
-                    if (otherEnums.size() == 1) {
-                        // we are adding the same enum value for the second time
-                        // prefix other enum's value
-                        auto& otherEnum = *otherEnums[0];
-                        const auto it = std::find_if(std::begin(otherEnum.values), std::end(otherEnum.values), [&](const EnumValue& ov) {
-                            return ov.name() == v.name();
-                        });
-                        if (it == std::end(otherEnum.values))
-                            throw std::logic_error("Enum value resolves to an enum which does not have the value");
-                        it->customName = otherEnum.name + "_" + it->cpacsName;
-                    }
-                    if (otherEnums.size() > 1) {
-                        // we are adding an already added value, prefix myself
-                        v.customName = e.name + "_" + v.cpacsName;
-                    }
-
-                    otherEnums.push_back(&e);
-                }
-            }
-
-            std::cout << "Prefixed the following enum values:" << std::endl;
-            for (auto& p : valueToEnum) {
-                const auto& otherEnums = p.second;
-                if (otherEnums.size() > 1) {
-                    std::cout << '\t' << p.first << std::endl;
-                    for (const auto& e : otherEnums)
-                        std::cout << "\t\t" << e->name << std::endl;
-                }
-            }
-        }
-
         auto checkAndPrintNode(const std::string& name, const Table& pruneList, unsigned int level) {
             if (pruneList.contains(name)) {
                 std::cout << std::string(level, '\t') <<  "pruning " << name << std::endl;
@@ -570,7 +530,6 @@ namespace tigl {
         builder.collapseEnums();
         builder.buildDependencies();
         builder.runPruneList();
-        builder.prefixClashedEnumValues();
         return {
             std::move(builder.m_classes),
             std::move(builder.m_enums)

--- a/src/lib/runtime/TixiHelper.h
+++ b/src/lib/runtime/TixiHelper.h
@@ -56,28 +56,25 @@ namespace tixi
         const int childCount = TixiGetNamedChildrenCount(tixiHandle, xpath);
 
         // validate number of child nodes
-        if (minOccurs >= 0) {
-            if (childCount < minOccurs) {
+        if (childCount < minOccurs) {
 #ifndef CPACS_GEN
-                LOG(ERROR)
-                    << "Not enough child nodes for element\n"
-                    << "xpath: " << xpath << "\n"
-                    << "minimum: " << minOccurs << "\n"
-                    << "actual: " << childCount;
+            LOG(ERROR)
+                << "Not enough child nodes for element\n"
+                << "xpath: " << xpath << "\n"
+                << "minimum: " << minOccurs << "\n"
+                << "actual: " << childCount;
 #endif
-            }
         }
-        if (maxOccurs >= 0) {
-            if (childCount > maxOccurs) {
-                // TODO: replace by exception/warning
+
+        if (childCount > maxOccurs) {
+            // TODO: replace by exception/warning
 #ifndef CPACS_GEN
-                LOG(ERROR)
-                    << "Too many child nodes for element\n"
-                    << "xpath: " << xpath << "\n"
-                    << "maximum: " << maxOccurs << "\n"
-                    << "actual: " << childCount;
+            LOG(ERROR)
+                << "Too many child nodes for element\n"
+                << "xpath: " << xpath << "\n"
+                << "maximum: " << maxOccurs << "\n"
+                << "actual: " << childCount;
 #endif
-            }
         }
 
         // read child nodes

--- a/src/lib/runtime/TixiHelper.h
+++ b/src/lib/runtime/TixiHelper.h
@@ -23,6 +23,7 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <ctime>
+#include <string>
 
 #include "UniquePtr.h"
 #ifndef CPACS_GEN
@@ -79,7 +80,7 @@ namespace tixi
 
         // read child nodes
         for (int i = 0; i < childCount; i++) {
-            const std::string childXPath = xpath + "[" + internal::to_string(i + 1) + "]";
+            const std::string childXPath = xpath + "[" + std::to_string(i + 1) + "]";
             try {
                 children.push_back(readChild(childXPath, std::forward<ChildCtorArgs>(args)...));
             } catch (const std::exception& e) {
@@ -133,7 +134,7 @@ namespace tixi
             // iteratore over all child nodes
             for (std::size_t i = 0; i < children.size(); i++) {
                 // if child node does not exist, create it
-                const std::string& childPath = xpath + "[" + internal::to_string(i + 1) + "]";
+                const std::string& childPath = xpath + "[" + std::to_string(i + 1) + "]";
                 if (!TixiCheckElement(tixiHandle, childPath)) {
                     TixiCreateElement(tixiHandle, xpath);
                 }
@@ -145,7 +146,7 @@ namespace tixi
             
         // delete old children which where not overwritten
         for (std::size_t i = children.size() + 1; i <= static_cast<std::size_t>(childCount); i++) {
-            TixiRemoveElement(tixiHandle, xpath + "[" + internal::to_string(children.size() + 1) + "]");
+            TixiRemoveElement(tixiHandle, xpath + "[" + std::to_string(children.size() + 1) + "]");
         }
     }
 
@@ -159,9 +160,9 @@ namespace tixi
     }
 
     template<typename T>
-    void TixiSaveElements(const TixiDocumentHandle& tixiHandle, const std::string& xpath, const std::vector<tigl::unique_ptr<T>>& children)
+    void TixiSaveElements(const TixiDocumentHandle& tixiHandle, const std::string& xpath, const std::vector<std::unique_ptr<T>>& children)
     {
-        auto writer = [&](const std::string& childXPath, const tigl::unique_ptr<T>& child) {
+        auto writer = [&](const std::string& childXPath, const std::unique_ptr<T>& child) {
             child->WriteCPACS(tixiHandle, childXPath);
         };
         TixiSaveElementsInternal(tixiHandle, xpath, children, writer);

--- a/src/lib/runtime/TixiHelper.h
+++ b/src/lib/runtime/TixiHelper.h
@@ -49,8 +49,8 @@ namespace tixi
     }
 
 
-    template<typename T, typename ReadChildFunc>
-    void TixiReadElementsInternal(const TixiDocumentHandle& tixiHandle, const std::string& xpath, std::vector<T>& children, int minOccurs, int maxOccurs, ReadChildFunc readChild)
+    template<typename T, typename ReadChildFunc, typename... ChildCtorArgs>
+    void TixiReadElementsInternal(const TixiDocumentHandle& tixiHandle, const std::string& xpath, std::vector<T>& children, int minOccurs, int maxOccurs, ReadChildFunc readChild, ChildCtorArgs&&... args)
     {
         // read number of child nodes
         const int childCount = TixiGetNamedChildrenCount(tixiHandle, xpath);
@@ -81,7 +81,7 @@ namespace tixi
         for (int i = 0; i < childCount; i++) {
             const std::string childXPath = xpath + "[" + internal::to_string(i + 1) + "]";
             try {
-                children.push_back(readChild(childXPath));
+                children.push_back(readChild(childXPath, std::forward<ChildCtorArgs>(args)...));
             } catch (const std::exception& e) {
 #ifdef CPACS_GEN
                 throw;
@@ -95,21 +95,31 @@ namespace tixi
     template<typename T>
     void TixiReadElements(const TixiDocumentHandle& tixiHandle, const std::string& xpath, std::vector<T>& children, int minOccurs, int maxOccurs)
     {
-        auto reader = [&](const std::string& childXPath) {
+        TixiReadElementsInternal(tixiHandle, xpath, children, minOccurs, maxOccurs, [&](const std::string& childXPath) {
             return TixiGetElement<T>(tixiHandle, childXPath);
-        };
-        TixiReadElementsInternal(tixiHandle, xpath, children, minOccurs, maxOccurs, reader);
+        });
     }
 
     template<typename T, typename... ChildCtorArgs>
-    void TixiReadElements(const TixiDocumentHandle& tixiHandle, const std::string& xpath, std::vector<tigl::unique_ptr<T>>& children, int minOccurs, int maxOccurs, ChildCtorArgs&&... args)
+    void TixiReadElements(const TixiDocumentHandle& tixiHandle, const std::string& xpath, std::vector<std::unique_ptr<T>>& children, int minOccurs, int maxOccurs, ChildCtorArgs&&... args)
     {
-        auto reader = [&](const std::string& childXPath) {
-            auto child = tigl::make_unique<T>(std::forward<ChildCtorArgs>(args)...);
-            child->ReadCPACS(tixiHandle, childXPath);
-            return child;
+        // TODO(bgruber): enable when support for g++ < 4.9.0 is dropped
+        //TixiReadElementsInternal(tixiHandle, xpath, children, minOccurs, maxOccurs, [&](const std::string& childXPath) {
+        //    auto child = tigl::make_unique<T>(std::forward<ChildCtorArgs>(args)...);
+        //    child->ReadCPACS(tixiHandle, childXPath);
+        //    return child;
+        //});
+        struct Reader {
+            std::unique_ptr<T> operator()(const std::string& childXPath, ChildCtorArgs&&... args) const
+            {
+                auto child = tigl::make_unique<T>(std::forward<ChildCtorArgs>(args)...);
+                child->ReadCPACS(tixiHandle, childXPath);
+                return child;
+            }
+
+            const TixiDocumentHandle& tixiHandle;
         };
-        TixiReadElementsInternal(tixiHandle, xpath, children, minOccurs, maxOccurs, reader);
+        TixiReadElementsInternal(tixiHandle, xpath, children, minOccurs, maxOccurs, Reader{tixiHandle}, std::forward<ChildCtorArgs>(args)...);
     }
 
     template<typename T, typename WriteChildFunc>

--- a/src/lib/runtime/TixiHelper.h
+++ b/src/lib/runtime/TixiHelper.h
@@ -58,22 +58,25 @@ namespace tixi
         // validate number of child nodes
         if (minOccurs >= 0) {
             if (childCount < minOccurs) {
-                // TODO: replace by exception/warning
-                std::cerr
+#ifndef CPACS_GEN
+                LOG(ERROR)
                     << "Not enough child nodes for element\n"
                     << "xpath: " << xpath << "\n"
                     << "minimum: " << minOccurs << "\n"
                     << "actual: " << childCount;
+#endif
             }
         }
         if (maxOccurs >= 0) {
             if (childCount > maxOccurs) {
                 // TODO: replace by exception/warning
-                std::cerr
+#ifndef CPACS_GEN
+                LOG(ERROR)
                     << "Too many child nodes for element\n"
                     << "xpath: " << xpath << "\n"
                     << "maximum: " << maxOccurs << "\n"
                     << "actual: " << childCount;
+#endif
             }
         }
 

--- a/src/lib/runtime/TixiHelper.h
+++ b/src/lib/runtime/TixiHelper.h
@@ -50,7 +50,7 @@ namespace tixi
 
 
     template<typename T, typename ReadChildFunc>
-    void TixiReadElements(const TixiDocumentHandle& tixiHandle, const std::string& xpath, std::vector<T>& children, ReadChildFunc readChild, int minOccurs = -1, int maxOccurs = -1)
+    void TixiReadElementsInternal(const TixiDocumentHandle& tixiHandle, const std::string& xpath, std::vector<T>& children, int minOccurs, int maxOccurs, ReadChildFunc readChild)
     {
         // read number of child nodes
         const int childCount = TixiGetNamedChildrenCount(tixiHandle, xpath);
@@ -81,7 +81,7 @@ namespace tixi
         for (int i = 0; i < childCount; i++) {
             const std::string childXPath = xpath + "[" + internal::to_string(i + 1) + "]";
             try {
-                children.push_back(readChild(tixiHandle, childXPath));
+                children.push_back(readChild(childXPath));
             } catch (const std::exception& e) {
 #ifdef CPACS_GEN
                 throw;
@@ -93,84 +93,27 @@ namespace tixi
     }
 
     template<typename T>
-    struct PrimitiveChildReader
+    void TixiReadElements(const TixiDocumentHandle& tixiHandle, const std::string& xpath, std::vector<T>& children, int minOccurs, int maxOccurs)
     {
-        T operator()(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const
-        {
-            return TixiGetElement<T>(tixiHandle, xpath);
-        }
-    };
-
-    template<typename T>
-    void TixiReadElements(const TixiDocumentHandle& tixiHandle, const std::string& xpath, std::vector<T>& children, int minOccurs = -1, int maxOccurs = -1)
-    {
-        TixiReadElements(tixiHandle, xpath, children, PrimitiveChildReader<T>(), minOccurs, maxOccurs);
+        auto reader = [&](const std::string& childXPath) {
+            return TixiGetElement<T>(tixiHandle, childXPath);
+        };
+        TixiReadElementsInternal(tixiHandle, xpath, children, minOccurs, maxOccurs, reader);
     }
 
-    template<typename T>
-    struct ChildReader
+    template<typename T, typename... ChildCtorArgs>
+    void TixiReadElements(const TixiDocumentHandle& tixiHandle, const std::string& xpath, std::vector<tigl::unique_ptr<T>>& children, int minOccurs, int maxOccurs, ChildCtorArgs&&... args)
     {
-        tigl::unique_ptr<T> operator()(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const
-        {
-            tigl::unique_ptr<T> child = tigl::make_unique<T>();
-            child->ReadCPACS(tixiHandle, xpath);
+        auto reader = [&](const std::string& childXPath) {
+            auto child = tigl::make_unique<T>(std::forward<ChildCtorArgs>(args)...);
+            child->ReadCPACS(tixiHandle, childXPath);
             return child;
-        }
-    };
-
-    template<typename T>
-    void TixiReadElements(const TixiDocumentHandle& tixiHandle, const std::string& xpath, std::vector<tigl::unique_ptr<T> >& children, int minOccurs = -1, int maxOccurs = -1)
-    {
-        TixiReadElements(tixiHandle, xpath, children, ChildReader<T>(), minOccurs, maxOccurs);
-    }
-
-    template<typename T, typename Arg1>
-    struct ChildWithArgsReader1
-    {
-        ChildWithArgsReader1(Arg1* arg1) : m_arg1(arg1) {}
-
-        tigl::unique_ptr<T> operator()(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const
-        {
-            tigl::unique_ptr<T> child = tigl::make_unique<T>(m_arg1);
-            child->ReadCPACS(tixiHandle, xpath);
-            return child;
-        }
-
-    private:
-        Arg1* m_arg1;
-    };
-
-    template<typename T, typename Arg1>
-    void TixiReadElements(const TixiDocumentHandle& tixiHandle, const std::string& xpath, std::vector<tigl::unique_ptr<T> >& children, Arg1* arg1, int minOccurs = -1, int maxOccurs = -1)
-    {
-        TixiReadElements(tixiHandle, xpath, children, ChildWithArgsReader1<T, Arg1>(arg1), minOccurs, maxOccurs);
-    }
-
-    template<typename T, typename Arg1, typename Arg2>
-    struct ChildWithArgsReader2
-    {
-        ChildWithArgsReader2(Arg1* arg1, Arg2* arg2) : m_arg1(arg1), m_arg2(arg2) {}
-
-        tigl::unique_ptr<T> operator()(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const
-        {
-            tigl::unique_ptr<T> child = tigl::make_unique<T>(m_arg1, m_arg2);
-            child->ReadCPACS(tixiHandle, xpath);
-            return child;
-        }
-
-    private:
-        Arg1* m_arg1;
-        Arg2* m_arg2;
-    };
-
-    template<typename T, typename Arg1, typename Arg2>
-    void TixiReadElements(const TixiDocumentHandle& tixiHandle, const std::string& xpath, std::vector<tigl::unique_ptr<T> >& children, Arg1* arg1, Arg2* arg2, int minOccurs = -1, int maxOccurs = -1)
-    {
-        TixiReadElements(tixiHandle, xpath, children, ChildWithArgsReader2<T, Arg1, Arg2>(arg1, arg2), minOccurs, maxOccurs);
+        };
+        TixiReadElementsInternal(tixiHandle, xpath, children, minOccurs, maxOccurs, reader);
     }
 
     template<typename T, typename WriteChildFunc>
-    void TixiSaveElements(const TixiDocumentHandle& tixiHandle, const std::string& xpath, const std::vector<T>& children, WriteChildFunc writeChild)
+    void TixiSaveElementsInternal(const TixiDocumentHandle& tixiHandle, const std::string& xpath, const std::vector<T>& children, WriteChildFunc writeChild)
     {
         // get number of children
         const int childCount = TixiGetNamedChildrenCount(tixiHandle, xpath);
@@ -186,7 +129,7 @@ namespace tixi
                 }
 
                 // write child node
-                writeChild(tixiHandle, childPath, children[i]);
+                writeChild(childPath, children[i]);
             }
         }
             
@@ -197,32 +140,20 @@ namespace tixi
     }
 
     template<typename T>
-    struct PrimitiveChildWriter
-    {
-        void operator()(const TixiDocumentHandle& tixiHandle, const std::string& xpath, const T& child) const
-        {
-            TixiSaveElement(tixiHandle, xpath, child);
-        }
-    };
-
-    template<typename T>
     void TixiSaveElements(const TixiDocumentHandle& tixiHandle, const std::string& xpath, const std::vector<T>& children)
     {
-        TixiSaveElements(tixiHandle, xpath, children, PrimitiveChildWriter<T>());
+        auto writer = [&](const std::string& childXPath, const T& child) {
+            TixiSaveElement(tixiHandle, childXPath, child);
+        };
+        TixiSaveElementsInternal(tixiHandle, xpath, children, writer);
     }
 
     template<typename T>
-    struct ChildWriter
+    void TixiSaveElements(const TixiDocumentHandle& tixiHandle, const std::string& xpath, const std::vector<tigl::unique_ptr<T>>& children)
     {
-        void operator()(const TixiDocumentHandle& tixiHandle, const std::string& xpath, const tigl::unique_ptr<T>& child) const
-        {
-            child->WriteCPACS(tixiHandle, xpath);
-        }
-    };
-
-    template<typename T>
-    void TixiSaveElements(const TixiDocumentHandle& tixiHandle, const std::string& xpath, const std::vector<tigl::unique_ptr<T> >& children)
-    {
-        TixiSaveElements(tixiHandle, xpath, children, ChildWriter<T>());
+        auto writer = [&](const std::string& childXPath, const tigl::unique_ptr<T>& child) {
+            child->WriteCPACS(tixiHandle, childXPath);
+        };
+        TixiSaveElementsInternal(tixiHandle, xpath, children, writer);
     }
 }

--- a/src/lib/runtime/UniquePtr.h
+++ b/src/lib/runtime/UniquePtr.h
@@ -17,16 +17,10 @@
 
 #pragma once
 
-#include <cstddef>
 #include <memory>
-
-#ifndef CPACS_GEN
-#include "tigl_config.h"
-#endif
 
 namespace tigl
 {
-#if defined (HAVE_STDUNIQUE_PTR) && defined (HAVE_CPP11)
     template <typename T>
     using unique_ptr = std::unique_ptr<T>;
 
@@ -35,58 +29,4 @@ namespace tigl
     {
         return unique_ptr<T>(new T(std::forward<Args>(args)...));
     }
-#else
-    template <typename T>
-    class unique_ptr : public std::auto_ptr<T>
-    {
-    public:
-        explicit unique_ptr(T* p = NULL) throw() : std::auto_ptr<T>(p) {}
-
-        // NOTE: const is a hack to allow std::vector<unique_ptr<T>>
-        unique_ptr(const unique_ptr& other) throw() : std::auto_ptr<T>(const_cast<unique_ptr&>(other)) {}
-
-        // NOTE: const is a hack to allow std::vector<unique_ptr<T>>
-        template <typename U>
-        unique_ptr(const unique_ptr<U>& other) throw() : std::auto_ptr<T>(const_cast<unique_ptr<U>&>(other)) {}
-
-        // NOTE: const is a hack to allow std::vector<unique_ptr<T>>
-        unique_ptr& operator=(const unique_ptr& other) throw()
-        {
-            std::auto_ptr<T>::operator=(const_cast<unique_ptr&>(other));
-            return *this;
-        }
-
-        // NOTE: const is a hack to allow std::vector<unique_ptr<T>>
-        template <typename U>
-        unique_ptr& operator=(const unique_ptr<U>& other) throw()
-        {
-            std::auto_ptr<T>::operator=(const_cast<unique_ptr<U>&>(other));
-            return *this;
-        }
-
-        operator bool() const
-        {
-            return std::auto_ptr<T>::get() != NULL;
-        }
-    };
-
-    template <typename T> unique_ptr<T> make_unique() { return unique_ptr<T>(new T()); }
-
-    template <typename T, typename Arg1> unique_ptr<T> make_unique(      Arg1& arg1) { return unique_ptr<T>(new T(arg1)); }
-    template <typename T, typename Arg1> unique_ptr<T> make_unique(const Arg1& arg1) { return unique_ptr<T>(new T(arg1)); }
-
-    template <typename T, typename Arg1, typename Arg2> unique_ptr<T> make_unique(      Arg1& arg1,       Arg2& arg2) { return unique_ptr<T>(new T(arg1, arg2)); }
-    template <typename T, typename Arg1, typename Arg2> unique_ptr<T> make_unique(      Arg1& arg1, const Arg2& arg2) { return unique_ptr<T>(new T(arg1, arg2)); }
-    template <typename T, typename Arg1, typename Arg2> unique_ptr<T> make_unique(const Arg1& arg1,       Arg2& arg2) { return unique_ptr<T>(new T(arg1, arg2)); }
-    template <typename T, typename Arg1, typename Arg2> unique_ptr<T> make_unique(const Arg1& arg1, const Arg2& arg2) { return unique_ptr<T>(new T(arg1, arg2)); }
-
-    template <typename T, typename Arg1, typename Arg2, typename Arg3> unique_ptr<T> make_unique(      Arg1& arg1,       Arg2& arg2, const Arg3& arg3) { return unique_ptr<T>(new T(arg1, arg2, arg3)); }
-    template <typename T, typename Arg1, typename Arg2, typename Arg3> unique_ptr<T> make_unique(      Arg1& arg1,       Arg2& arg2,       Arg3& arg3) { return unique_ptr<T>(new T(arg1, arg2, arg3)); }
-    template <typename T, typename Arg1, typename Arg2, typename Arg3> unique_ptr<T> make_unique(      Arg1& arg1, const Arg2& arg2, const Arg3& arg3) { return unique_ptr<T>(new T(arg1, arg2, arg3)); }
-    template <typename T, typename Arg1, typename Arg2, typename Arg3> unique_ptr<T> make_unique(      Arg1& arg1, const Arg2& arg2,       Arg3& arg3) { return unique_ptr<T>(new T(arg1, arg2, arg3)); }
-    template <typename T, typename Arg1, typename Arg2, typename Arg3> unique_ptr<T> make_unique(const Arg1& arg1,       Arg2& arg2, const Arg3& arg3) { return unique_ptr<T>(new T(arg1, arg2, arg3)); }
-    template <typename T, typename Arg1, typename Arg2, typename Arg3> unique_ptr<T> make_unique(const Arg1& arg1,       Arg2& arg2,       Arg3& arg3) { return unique_ptr<T>(new T(arg1, arg2, arg3)); }
-    template <typename T, typename Arg1, typename Arg2, typename Arg3> unique_ptr<T> make_unique(const Arg1& arg1, const Arg2& arg2, const Arg3& arg3) { return unique_ptr<T>(new T(arg1, arg2, arg3)); }
-    template <typename T, typename Arg1, typename Arg2, typename Arg3> unique_ptr<T> make_unique(const Arg1& arg1, const Arg2& arg2,       Arg3& arg3) { return unique_ptr<T>(new T(arg1, arg2, arg3)); }
-#endif
 }

--- a/src/lib/runtime/UniquePtr.h
+++ b/src/lib/runtime/UniquePtr.h
@@ -22,11 +22,11 @@
 namespace tigl
 {
     template <typename T>
-    using unique_ptr = std::unique_ptr<T>;
+    using unique_ptr [[deprecated]] = std::unique_ptr<T>;
 
     template<typename T, typename... Args>
-    auto make_unique(Args&&... args) -> unique_ptr<T>
+    auto make_unique(Args&&... args) -> std::unique_ptr<T>
     {
-        return unique_ptr<T>(new T(std::forward<Args>(args)...));
+        return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
     }
 }

--- a/test/data/all/ref.cpp
+++ b/test/data/all/ref.cpp
@@ -65,25 +65,16 @@ namespace generated
         int                  m_f;
 
     private:
-#ifdef HAVE_CPP11
         CPACSRoot(const CPACSRoot&) = delete;
         CPACSRoot& operator=(const CPACSRoot&) = delete;
 
         CPACSRoot(CPACSRoot&&) = delete;
         CPACSRoot& operator=(CPACSRoot&&) = delete;
-#else
-        CPACSRoot(const CPACSRoot&);
-        CPACSRoot& operator=(const CPACSRoot&);
-#endif
     };
 } // namespace generated
 
 // Aliases in tigl namespace
-#ifdef HAVE_CPP11
 using CCPACSRoot = generated::CPACSRoot;
-#else
-typedef generated::CPACSRoot CCPACSRoot;
-#endif
 } // namespace tigl
 // Copyright (c) 2018 RISC Software GmbH
 //

--- a/test/data/choice/ref.cpp
+++ b/test/data/choice/ref.cpp
@@ -51,25 +51,16 @@ namespace generated
         boost::optional<int> m_b_choice2;
 
     private:
-#ifdef HAVE_CPP11
         CPACSRoot(const CPACSRoot&) = delete;
         CPACSRoot& operator=(const CPACSRoot&) = delete;
 
         CPACSRoot(CPACSRoot&&) = delete;
         CPACSRoot& operator=(CPACSRoot&&) = delete;
-#else
-        CPACSRoot(const CPACSRoot&);
-        CPACSRoot& operator=(const CPACSRoot&);
-#endif
     };
 } // namespace generated
 
 // Aliases in tigl namespace
-#ifdef HAVE_CPP11
 using CCPACSRoot = generated::CPACSRoot;
-#else
-typedef generated::CPACSRoot CCPACSRoot;
-#endif
 } // namespace tigl
 // Copyright (c) 2018 RISC Software GmbH
 //

--- a/test/data/documentation/ref.cpp
+++ b/test/data/documentation/ref.cpp
@@ -62,25 +62,16 @@ namespace generated
         int m_b;
 
     private:
-#ifdef HAVE_CPP11
         CPACSRoot(const CPACSRoot&) = delete;
         CPACSRoot& operator=(const CPACSRoot&) = delete;
 
         CPACSRoot(CPACSRoot&&) = delete;
         CPACSRoot& operator=(CPACSRoot&&) = delete;
-#else
-        CPACSRoot(const CPACSRoot&);
-        CPACSRoot& operator=(const CPACSRoot&);
-#endif
     };
 } // namespace generated
 
 // Aliases in tigl namespace
-#ifdef HAVE_CPP11
 using CCPACSRoot = generated::CPACSRoot;
-#else
-typedef generated::CPACSRoot CCPACSRoot;
-#endif
 } // namespace tigl
 // Copyright (c) 2018 RISC Software GmbH
 //

--- a/test/data/sequence/ref.cpp
+++ b/test/data/sequence/ref.cpp
@@ -78,25 +78,16 @@ namespace generated
         std::vector<int>     m_is;
 
     private:
-#ifdef HAVE_CPP11
         CPACSRoot(const CPACSRoot&) = delete;
         CPACSRoot& operator=(const CPACSRoot&) = delete;
 
         CPACSRoot(CPACSRoot&&) = delete;
         CPACSRoot& operator=(CPACSRoot&&) = delete;
-#else
-        CPACSRoot(const CPACSRoot&);
-        CPACSRoot& operator=(const CPACSRoot&);
-#endif
     };
 } // namespace generated
 
 // Aliases in tigl namespace
-#ifdef HAVE_CPP11
 using CCPACSRoot = generated::CPACSRoot;
-#else
-typedef generated::CPACSRoot CCPACSRoot;
-#endif
 } // namespace tigl
 // Copyright (c) 2018 RISC Software GmbH
 //
@@ -169,7 +160,7 @@ namespace generated
 
         // read element e
         if (tixi::TixiCheckElement(tixiHandle, xpath + "/e")) {
-            tixi::TixiReadElements(tixiHandle, xpath + "/e", m_es);
+            tixi::TixiReadElements(tixiHandle, xpath + "/e", m_es, 1, 2147483647);
         }
 
         // read element f
@@ -179,7 +170,7 @@ namespace generated
 
         // read element g
         if (tixi::TixiCheckElement(tixiHandle, xpath + "/g")) {
-            tixi::TixiReadElements(tixiHandle, xpath + "/g", m_gs);
+            tixi::TixiReadElements(tixiHandle, xpath + "/g", m_gs, 0, 2147483647);
         }
 
         // read element h
@@ -192,7 +183,7 @@ namespace generated
 
         // read element i
         if (tixi::TixiCheckElement(tixiHandle, xpath + "/i")) {
-            tixi::TixiReadElements(tixiHandle, xpath + "/i", m_is);
+            tixi::TixiReadElements(tixiHandle, xpath + "/i", m_is, 1, 2147483647);
         }
 
     }

--- a/test/data/sequence/ref.cpp
+++ b/test/data/sequence/ref.cpp
@@ -160,7 +160,7 @@ namespace generated
 
         // read element e
         if (tixi::TixiCheckElement(tixiHandle, xpath + "/e")) {
-            tixi::TixiReadElements(tixiHandle, xpath + "/e", m_es, 1, xsdUnbounded);
+            tixi::TixiReadElements(tixiHandle, xpath + "/e", m_es, 1, tixi::xsdUnbounded);
         }
 
         // read element f
@@ -170,7 +170,7 @@ namespace generated
 
         // read element g
         if (tixi::TixiCheckElement(tixiHandle, xpath + "/g")) {
-            tixi::TixiReadElements(tixiHandle, xpath + "/g", m_gs, 0, xsdUnbounded);
+            tixi::TixiReadElements(tixiHandle, xpath + "/g", m_gs, 0, tixi::xsdUnbounded);
         }
 
         // read element h
@@ -183,7 +183,7 @@ namespace generated
 
         // read element i
         if (tixi::TixiCheckElement(tixiHandle, xpath + "/i")) {
-            tixi::TixiReadElements(tixiHandle, xpath + "/i", m_is, 1, xsdUnbounded);
+            tixi::TixiReadElements(tixiHandle, xpath + "/i", m_is, 1, tixi::xsdUnbounded);
         }
 
     }

--- a/test/data/sequence/ref.cpp
+++ b/test/data/sequence/ref.cpp
@@ -160,7 +160,7 @@ namespace generated
 
         // read element e
         if (tixi::TixiCheckElement(tixiHandle, xpath + "/e")) {
-            tixi::TixiReadElements(tixiHandle, xpath + "/e", m_es, 1, 2147483647);
+            tixi::TixiReadElements(tixiHandle, xpath + "/e", m_es, 1, xsdUnbounded);
         }
 
         // read element f
@@ -170,7 +170,7 @@ namespace generated
 
         // read element g
         if (tixi::TixiCheckElement(tixiHandle, xpath + "/g")) {
-            tixi::TixiReadElements(tixiHandle, xpath + "/g", m_gs, 0, 2147483647);
+            tixi::TixiReadElements(tixiHandle, xpath + "/g", m_gs, 0, xsdUnbounded);
         }
 
         // read element h
@@ -183,7 +183,7 @@ namespace generated
 
         // read element i
         if (tixi::TixiCheckElement(tixiHandle, xpath + "/i")) {
-            tixi::TixiReadElements(tixiHandle, xpath + "/i", m_is, 1, 2147483647);
+            tixi::TixiReadElements(tixiHandle, xpath + "/i", m_is, 1, xsdUnbounded);
         }
 
     }


### PR DESCRIPTION
* removed custom unique_ptr
* merged overloads of TixiReadElements
* removed clashed enum prefixing, as enums can no longer clash
* removed option to generate scoped enums, they are generated by default now
* using std::unique_ptr instead of tigl::unique_ptr
* enabled deleted special member generation by default
* simplified a bit of generated code
* using using instead of typedef when generating exports into tigl namespace


- replaced std::cerr by LOG(ERROR) for non generator builds for cardinality error messages
- minOccurs and maxOccurs are now always interpreted
- updated test reference data
