### PR TITLE
Fixed issue in ReadCPACS if custom base class is defined

### DIFF
--- a/src/lib/CodeGen.cpp
+++ b/src/lib/CodeGen.cpp
@@ -638,7 +638,7 @@ namespace tigl {
             // classes
             const auto itC = m_types.classes.find(type);
             if (itC != std::end(m_types.classes)) {
-                cpp << type << "::ReadCPACS(tixiHandle, xpath);";
+                cpp << customReplacedType(type) << "::ReadCPACS(tixiHandle, xpath);";
                 return;
             }
 
@@ -655,7 +655,7 @@ namespace tigl {
             // classes
             const auto itC = m_types.classes.find(type);
             if (itC != std::end(m_types.classes)) {
-                cpp << type << "::WriteCPACS(tixiHandle, xpath);";
+                cpp << customReplacedType(type) << "::WriteCPACS(tixiHandle, xpath);";
                 return;
             }
 


### PR DESCRIPTION
I had this problem, when I derived a new type from an existing cpacs type in the cpacs schema.

It turned out, that the wrong ReadCPACS was called: the generated one, not the one from the custom derived class.

This small change fixes the issue for me and does not affect any other parts in TiGL.

See this TiGL commit for more information: https://github.com/DLR-SC/tigl/commit/03e695d247e8bf5613157b986de0c8dd88ff2494